### PR TITLE
AccountDb 를 추가하고 이를 이용해 id-pw 인증

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,5 @@ FodyWeavers.xsd
 # Generated code
 K2client/proto/
 
+# database file
+sample.sqlite3*

--- a/K2svc/Db/AccountDb.cs
+++ b/K2svc/Db/AccountDb.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Reflection;
+
+namespace K2svc.Db
+{
+    public class AccountDb
+        : DbContext // https://docs.microsoft.com/ko-kr/ef/core/miscellaneous/configuring-dbcontext
+    {
+        public DbSet<Account> Accounts { get; set; }
+
+        public AccountDb(ServiceConfiguration _config)
+        {
+            config = _config;
+            Database.EnsureCreated();
+
+#if DEBUG
+            // TEST environment
+            if (Accounts.Count() == 0)
+            {
+                Accounts.AddRange(new Account[] {
+                    new Account { AccountName = "k1", Password = "k1k1" },
+                    new Account { AccountName = "k2", Password = "k2k2" },
+                    new Account { AccountName = "k3", Password = "k3k3" },
+                    new Account { AccountName = "k4", Password = "k4k4" },
+                });
+                SaveChanges();
+            }
+#endif
+        }
+
+        #region DbContext override
+        protected override void OnConfiguring(DbContextOptionsBuilder builder)
+        {
+            // database provider 선택 ; 하드코딩없이 간편하게 
+            builder.UseSqlite($"filename={config.DatabaseFileName}", options =>
+            {
+                options.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName);
+            });
+
+            base.OnConfiguring(builder);
+        }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            // TODO: 하드코딩하지 않고 table 을 늘리거나 변경할 수 있도록(Attribute 이용?)
+            Account.OnModelCreating(builder.Entity<Account>());
+
+            base.OnModelCreating(builder);
+        }
+        #endregion
+
+        private readonly ServiceConfiguration config;
+    }
+
+}

--- a/K2svc/Db/Models.cs
+++ b/K2svc/Db/Models.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders; // for EntityTypeBuilder
+
+namespace K2svc.Db
+{
+    public class Account
+    {
+        public long Id { get; set; }
+        public string AccountName { get; set; }
+        public string Password { get; set; }
+
+        internal static void OnModelCreating(EntityTypeBuilder<Account> builder)
+        {
+            builder.HasKey(e => e.Id); // primary key
+            builder.Property(e => e.Id).ValueGeneratedOnAdd(); // auto increment
+            builder.HasIndex(e => e.AccountName).IsUnique(); // unique index
+        }
+    }
+}

--- a/K2svc/K2svc.csproj
+++ b/K2svc/K2svc.csproj
@@ -21,6 +21,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
   </ItemGroup>
 

--- a/K2svc/ServiceConfiguration.cs
+++ b/K2svc/ServiceConfiguration.cs
@@ -22,6 +22,9 @@ namespace K2svc
         public bool EnableServerManagementBackend { get; set; } = true;
         public bool EnableUserSessionBackend { get; set; } = true;
 
+        // as database
+        public string DatabaseFileName { get; set; } = "sample.sqlite3";
+
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
             return this;
@@ -37,6 +40,8 @@ namespace K2svc
 
             Data.Add($"{SECTION_NAME}:{nameof(EnableServerManagementBackend)}", $"{EnableServerManagementBackend}");
             Data.Add($"{SECTION_NAME}:{nameof(EnableUserSessionBackend)}", $"{EnableUserSessionBackend}");
+
+            Data.Add($"{SECTION_NAME}:{nameof(DatabaseFileName)}", $"{DatabaseFileName}");
         }
 
         // internal valuse to communicate

--- a/K2svc/Startup.cs
+++ b/K2svc/Startup.cs
@@ -25,6 +25,9 @@ namespace K2svc
             services.AddSingleton(config.GetSection(ServiceConfiguration.SECTION_NAME).Get<ServiceConfiguration>()); // 쉽게 접근해 사용할 수 있도록
             services.AddSingleton<Frontend.PushService.Singleton>();
 
+            // database
+            services.AddDbContext<Db.AccountDb>();
+
             // hosted services
             services.AddHostedService<Background.ServerManagementBackground>();
 


### PR DESCRIPTION
EF core - sqlite database 를 이용하는 id-pw 저장된 account db 사용하도록(InitService)

resolves #21 